### PR TITLE
IPCSey - pipe config through an IPC

### DIFF
--- a/Marsey.IPC/Client.cs
+++ b/Marsey.IPC/Client.cs
@@ -12,7 +12,6 @@ public class Client
         pipeClient.Connect();
 
         using StreamReader reader = new StreamReader(pipeClient);
-        string serialized = reader.ReadToEnd();
-        return serialized;
+        return reader.ReadToEnd();
     }
 }

--- a/Marsey.IPC/Client.cs
+++ b/Marsey.IPC/Client.cs
@@ -1,0 +1,18 @@
+﻿using System.IO.Pipes;
+
+
+namespace Marsey.IPC;
+
+public class Client
+{
+    public string ConnRecv(string name)
+    {
+        using NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", name, PipeDirection.In);
+
+        pipeClient.Connect();
+
+        using StreamReader reader = new StreamReader(pipeClient);
+        string serialized = reader.ReadToEnd();
+        return serialized;
+    }
+}

--- a/Marsey.IPC/Marsey.IPC.csproj
+++ b/Marsey.IPC/Marsey.IPC.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+</Project>

--- a/Marsey.IPC/Server.cs
+++ b/Marsey.IPC/Server.cs
@@ -11,7 +11,8 @@ public class Server
         await pipeServer.WaitForConnectionAsync();
 
         byte[] buffer = Encoding.UTF8.GetBytes(data);
-
         await pipeServer.WriteAsync(buffer);
+
+        pipeServer.Close();
     }
 }

--- a/Marsey.IPC/Server.cs
+++ b/Marsey.IPC/Server.cs
@@ -1,0 +1,17 @@
+﻿using System.IO.Pipes;
+using System.Text;
+
+namespace Marsey.IPC;
+
+public class Server
+{
+    public async Task ReadySend(string name, string data)
+    {
+        await using NamedPipeServerStream pipeServer = new NamedPipeServerStream(name, PipeDirection.Out);
+        await pipeServer.WaitForConnectionAsync();
+
+        byte[] buffer = Encoding.UTF8.GetBytes(data);
+
+        await pipeServer.WriteAsync(buffer);
+    }
+}

--- a/Marsey/Config/MarseyConf.cs
+++ b/Marsey/Config/MarseyConf.cs
@@ -22,19 +22,16 @@ public static class MarseyConf
 
     /// <summary>
     /// Should we log anything from the loader
-    /// <see cref="Utility.SetupFlags"/>
     /// </summary>
     public static bool Logging;
 
     /// <summary>
     /// Log DEBG messages
-    /// <see cref="Utility.SetupFlags"/>
     /// </summary>
     public static bool DebugAllowed;
 
     /// <summary>
     /// Throws an exception on client if any patch had failed applying.
-    /// <see cref="Utility.SetupFlags"/>
     /// </summary>
     public static bool ThrowOnFail;
 

--- a/Marsey/Config/MarseyConf.cs
+++ b/Marsey/Config/MarseyConf.cs
@@ -1,4 +1,5 @@
 using Marsey.Game.Patches;
+using Marsey.Game.Patches.Marseyports;
 using Marsey.Misc;
 using Marsey.Stealthsey;
 
@@ -68,19 +69,23 @@ public static class MarseyConf
     /// </summary>
     public static bool DisableAnyBackports;
 
-    public static readonly Dictionary<string, Action<bool>> EnvVarMap = new Dictionary<string, Action<bool>>
+    public static readonly Dictionary<string, Action<string>> EnvVarMap = new Dictionary<string, Action<string>>
     {
-        { "MARSEY_LOGGING", value => Logging = value },
-        { "MARSEY_LOADER_DEBUG", value => DebugAllowed = value },
-        { "MARSEY_THROW_FAIL", value => ThrowOnFail = value },
-        { "MARSEY_SEPARATE_LOGGER", value => SeparateLogger = value },
-        { "MARSEY_DISABLE_STRICT", value => DisableResPackStrict = value},
-        { "MARSEY_FORCINGHWID", value => ForceHWID = value },
-        { "MARSEY_DISABLE_PRESENCE", value => KillRPC = value },
-        { "MARSEY_DUMP_ASSEMBLIES", value => Dumper = value },
-        { "MARSEY_JAMMER", value => JamDials = value },
-        { "MARSEY_DISABLE_REC", value => DisableREC = value },
-        { "MARSEY_BACKPORTS", value => Backports = value},
-        { "MARSEY_NO_ANY_BACKPORTS", value => DisableAnyBackports = value}
+        { "MARSEY_LOGGING", value => Logging = value == "true" },
+        { "MARSEY_LOADER_DEBUG", value => DebugAllowed = value == "true" },
+        { "MARSEY_THROW_FAIL", value => ThrowOnFail = value == "true" },
+        { "MARSEY_SEPARATE_LOGGER", value => SeparateLogger = value == "true" },
+        { "MARSEY_DISABLE_STRICT", value => DisableResPackStrict = value == "true" },
+        { "MARSEY_FORCINGHWID", value => ForceHWID = value == "true" },
+        { "MARSEY_FORCEDHWID", value => HWID.SetHWID(value)},
+        { "MARSEY_DISABLE_PRESENCE", value => KillRPC = value == "true" },
+        { "MARSEY_DUMP_ASSEMBLIES", value => Dumper = value == "true" },
+        { "MARSEY_JAMMER", value => JamDials = value == "true" },
+        { "MARSEY_DISABLE_REC", value => DisableREC = value == "true" },
+        { "MARSEY_BACKPORTS", value => Backports = value == "true" },
+        { "MARSEY_NO_ANY_BACKPORTS", value => DisableAnyBackports = value == "true" },
+        { "MARSEY_FORKID", MarseyPortMan.SetForkID },
+        { "MARSEY_ENGINE", MarseyPortMan.SetEngineVer },
+        { "MARSEY_HIDE_LEVEL", value => MarseyHide = (HideLevel)Enum.Parse(typeof(HideLevel), value) }
     };
 }

--- a/Marsey/Game/Patches/HWID.cs
+++ b/Marsey/Game/Patches/HWID.cs
@@ -13,7 +13,7 @@ namespace Marsey.Game.Patches;
 public static class HWID
 {
     private static byte[] _hwId = Array.Empty<byte>();
-    private const string HWIDEnv = "MARSEY_FORCEDHWID";
+    private static string _hwidString = "";
 
     /// <summary>
     /// Patching the HWId function and replacing it with a custom HWId.
@@ -32,16 +32,14 @@ public static class HWID
 
         MarseyLogger.Log(MarseyLogger.LogType.INFO, "HWIDForcer", "Starting");
 
-        string hwid = GetForcedHWId();
-        string cleanedHwid = CleanHwid(hwid);
+        string cleanedHwid = CleanHwid(_hwidString);
         ForceHWID(cleanedHwid);
         PatchCalcMethod();
     }
 
-    private static string GetForcedHWId()
+    public static void SetHWID(string? hwid)
     {
-        string? hwid = Envsey.CleanFlag(HWIDEnv);
-        return hwid ?? string.Empty;
+        _hwidString = hwid ?? string.Empty;
     }
 
     private static string CleanHwid(string hwid)
@@ -64,11 +62,11 @@ public static class HWID
         }
     }
 
-    public static string GenerateRandom(int length)
+    public static string GenerateRandom(int length = 64)
     {
         Random random = new Random();
-        const string chars = "0123456789abcdef";
-        StringBuilder result = new StringBuilder(length*2); // Were generating a string here actually, not an array of byte.
+        const string chars = "0123456789ABCDEF";
+        StringBuilder result = new StringBuilder(length);
 
         for (int i = 0; i < length; i++)
         {

--- a/Marsey/Game/Patches/Marseyports/MarseyPortMan.cs
+++ b/Marsey/Game/Patches/Marseyports/MarseyPortMan.cs
@@ -13,19 +13,18 @@ namespace Marsey.Game.Patches.Marseyports;
 /// </summary>
 public static class MarseyPortMan
 {
-    private static readonly string _forkenvvar = "MARSEY_FORKID";
-    private static readonly string _engineenvvar = "MARSEY_ENGINE";
     public static string fork = "";
     public static Version engine = new Version();
     private static IEnumerable<Type>? _backports;
+
+    public static void SetEngineVer(string eng) => engine = new Version(eng);
+    public static void SetForkID(string forkid) => fork = forkid;
 
     public static void Initialize()
     {
         // https://www.youtube.com/watch?v=vmUGxXrlRmE
         if (!MarseyConf.Backports) return;
 
-        fork = Envsey.CleanFlag(_forkenvvar)!;
-        engine = new Version(Envsey.CleanFlag(_engineenvvar)!);
         MarseyLogger.Log(MarseyLogger.LogType.DEBG, "Backporter", $"Starting backporter against fork \"{fork}\", engine {engine}.");
 
         IEnumerable<Type> backports = GetBackports();

--- a/Marsey/Marsey.csproj
+++ b/Marsey/Marsey.csproj
@@ -10,5 +10,9 @@
         <PackageReference Include="Lib.Harmony" />
         <PackageReference Include="Newtonsoft.Json" />
     </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Marsey.IPC\Marsey.IPC.csproj" />
+    </ItemGroup>
     
 </Project>

--- a/Marsey/Misc/Utility.cs
+++ b/Marsey/Misc/Utility.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using Marsey.Config;
+using Marsey.IPC;
 using Marsey.PatchAssembly;
 using Marsey.Stealthsey;
 
@@ -29,7 +30,7 @@ public static class MarseyLogger
 
         SharedLog($"[{logType.ToString()}] {message}");
     }
-    
+
     /// <summary>
     /// Ditto but specifying a system used
     /// </summary>
@@ -64,7 +65,7 @@ public abstract class Utility
     /// Checks loader environment variables, sets relevant flags in MarseyVars.
     /// Executed only by the loader.
     /// </summary>
-    public static void SetupFlags()
+    /*public static void SetupFlags()
     {
         foreach (KeyValuePair<string, Action<bool>> kvp in MarseyConf.EnvVarMap)
         {
@@ -72,11 +73,30 @@ public abstract class Utility
             MarseyLogger.Log(MarseyLogger.LogType.DEBG, "Marseyconf", $"{kvp.Key} returned {value}");
             kvp.Value(value);
         }
-    }
+    }*/
 
     private static bool CheckEnv(string envName)
     {
         string envVar = Envsey.CleanFlag(envName)!;
         return !string.IsNullOrEmpty(envVar) && bool.Parse(envVar);
+    }
+
+    public static void ReadConf()
+    {
+        Client MarseyConfPipeClient = new Client();
+        string config = MarseyConfPipeClient.ConnRecv("MarseyConf");
+
+        Dictionary<string, string> envVars = config.Split(';')
+            .Select(kv => kv.Split('='))
+            .ToDictionary(kv => kv[0], kv => kv[1]);
+
+        // Apply the environment variables to MarseyConf
+        foreach (KeyValuePair<string, string> kv in envVars)
+        {
+            if (!MarseyConf.EnvVarMap.TryGetValue(kv.Key, value: out Action<string>? value)) continue;
+
+            MarseyLogger.Log(MarseyLogger.LogType.DEBG, $"{kv.Key} read {kv.Value}");
+            value(kv.Value);
+        }
     }
 }

--- a/Marsey/Misc/Utility.cs
+++ b/Marsey/Misc/Utility.cs
@@ -61,20 +61,6 @@ public static class MarseyLogger
 }
 public abstract class Utility
 {
-    /// <summary>
-    /// Checks loader environment variables, sets relevant flags in MarseyVars.
-    /// Executed only by the loader.
-    /// </summary>
-    /*public static void SetupFlags()
-    {
-        foreach (KeyValuePair<string, Action<bool>> kvp in MarseyConf.EnvVarMap)
-        {
-            bool value = CheckEnv(kvp.Key);
-            MarseyLogger.Log(MarseyLogger.LogType.DEBG, "Marseyconf", $"{kvp.Key} returned {value}");
-            kvp.Value(value);
-        }
-    }*/
-
     private static bool CheckEnv(string envName)
     {
         string envVar = Envsey.CleanFlag(envName)!;

--- a/Marsey/Stealthsey/Hidesey.cs
+++ b/Marsey/Stealthsey/Hidesey.cs
@@ -74,10 +74,9 @@ public static class Hidesey
             return;
 
         _initialized = true;
-        
-        MarseyConf.MarseyHide = GetHideseyLevel();
+
         HideLevelExec.Initialize();
-        
+
         Load();
     }
 
@@ -85,11 +84,11 @@ public static class Hidesey
     private static void Load()
     {
         Disperse();
-        
+
         Facade.Imposition("Marsey");
 
         Perjurize(); // Patch detection methods
-        
+
         MarseyLogger.Log(MarseyLogger.LogType.INFO, $"Hidesey started. Running {MarseyConf.MarseyHide.ToString()} configuration.");
     }
 
@@ -125,7 +124,7 @@ public static class Hidesey
     {
         HWID.Force();
         DiscordRPC.Disable();
-        
+
         // Cleanup
         Disperse();
     }
@@ -147,7 +146,7 @@ public static class Hidesey
         MarseyLogger.Log(MarseyLogger.LogType.DEBG, $"Caching is set to {!_caching}");
         _caching = !_caching;
     }
-    
+
     /// <summary>
     /// Add assembly to _hideseys list
     /// </summary>
@@ -162,7 +161,7 @@ public static class Hidesey
             if (!recursive) return;
         }
     }
-    
+
     /// <summary>
     /// If we have the assembly object
     /// </summary>
@@ -191,7 +190,7 @@ public static class Hidesey
     private static void Perjurize()
     {
         MethodInfo? Lie = Helpers.GetMethod(typeof(HideseyPatches), "Lie");
-        
+
         (MethodInfo?, Type)[] patches =
         [
             (typeof(AppDomain).GetMethod(nameof(AppDomain.GetAssemblies)), typeof(Assembly[])),
@@ -211,17 +210,17 @@ public static class Hidesey
             );
         }
     }
-    
+
     /// <summary>
     /// Checks HideLevel env variable, defaults to Normal
     /// </summary>
     private static HideLevel GetHideseyLevel()
     {
         string envVar = Environment.GetEnvironmentVariable("MARSEY_HIDE_LEVEL")!;
-        
-        if (int.TryParse(envVar, out int hideLevelValue) && Enum.IsDefined(typeof(HideLevel), hideLevelValue)) 
+
+        if (int.TryParse(envVar, out int hideLevelValue) && Enum.IsDefined(typeof(HideLevel), hideLevelValue))
             return (HideLevel)hideLevelValue;
-        
+
         return HideLevel.Normal;
     }
 
@@ -267,7 +266,7 @@ public static class Hidesey
         Type[] cached = Facade.Cached;
 
         if (cached != Array.Empty<Type>()) return cached;
-        
+
         cached = original.Except(hiddentypes).ToArray();
         Facade.Cache(cached);
 

--- a/MarseyLoader.sln
+++ b/MarseyLoader.sln
@@ -46,6 +46,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marsey", "Marsey\Marsey.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marsey.Tests", "Marsey.Tests\Marsey.Tests.csproj", "{E47E0552-FF89-450D-880A-54B745481CD4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Marsey.IPC", "Marsey.IPC\Marsey.IPC.csproj", "{97CFAE49-9274-447A-832C-55BC360235EE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,6 +145,18 @@ Global
 		{E47E0552-FF89-450D-880A-54B745481CD4}.Release|x64.Build.0 = Release|Any CPU
 		{E47E0552-FF89-450D-880A-54B745481CD4}.Release|x86.ActiveCfg = Release|Any CPU
 		{E47E0552-FF89-450D-880A-54B745481CD4}.Release|x86.Build.0 = Release|Any CPU
+		{97CFAE49-9274-447A-832C-55BC360235EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97CFAE49-9274-447A-832C-55BC360235EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97CFAE49-9274-447A-832C-55BC360235EE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{97CFAE49-9274-447A-832C-55BC360235EE}.Debug|x64.Build.0 = Debug|Any CPU
+		{97CFAE49-9274-447A-832C-55BC360235EE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{97CFAE49-9274-447A-832C-55BC360235EE}.Debug|x86.Build.0 = Debug|Any CPU
+		{97CFAE49-9274-447A-832C-55BC360235EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97CFAE49-9274-447A-832C-55BC360235EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97CFAE49-9274-447A-832C-55BC360235EE}.Release|x64.ActiveCfg = Release|Any CPU
+		{97CFAE49-9274-447A-832C-55BC360235EE}.Release|x64.Build.0 = Release|Any CPU
+		{97CFAE49-9274-447A-832C-55BC360235EE}.Release|x86.ActiveCfg = Release|Any CPU
+		{97CFAE49-9274-447A-832C-55BC360235EE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{31D3CCC5-36F4-48C3-8885-E029A2026B57} = {12BB41B7-34BA-44EF-9ECA-434A276D83BD}

--- a/SS14.Launcher/Models/Connector.cs
+++ b/SS14.Launcher/Models/Connector.cs
@@ -593,7 +593,7 @@ public class Connector : ReactiveObject
         {
             { "MARSEY_LOADER_DEBUG", _cfg.GetCVar(CVars.LogLoaderDebug) ? "true" : null },
             { "MARSEY_LOGGING", _cfg.GetCVar(CVars.LogPatcher) ? "true" : null },
-            { "MARSEY_SEPARATE_LOGGER", MarseyConf.SeparateLogger ? "true" : null },
+            { "MARSEY_SEPARATE_LOGGER", _cfg.GetCVar(CVars.LogPatcher) ? "true" : null },
             { "MARSEY_THROW_FAIL", _cfg.GetCVar(CVars.ThrowPatchFail) ? "true" : null },
             { "MARSEY_HIDE_LEVEL", $"{_cfg.GetCVar(CVars.MarseyHide)}" },
             { "MARSEY_JAMMER", _cfg.GetCVar(CVars.JamDials) ? "true" : null },

--- a/SS14.Launcher/Models/Connector.cs
+++ b/SS14.Launcher/Models/Connector.cs
@@ -22,8 +22,10 @@ using SS14.Launcher.Models.Logins;
 using SS14.Launcher.Utility;
 using Marsey.Config;
 using Marsey.Game.Patches;
+using Marsey.IPC;
 using Marsey.Stealthsey;
 using Marsey.Misc;
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
 namespace SS14.Launcher.Models;
 
@@ -437,7 +439,7 @@ public class Connector : ReactiveObject
             return null;
         }
 
-        Marsify(startInfo);
+        Marsify();
 
         ConfigureEnvironmentVariables(startInfo, launchInfo, engineVersion);
         ConfigureLogging(startInfo);
@@ -572,52 +574,51 @@ public class Connector : ReactiveObject
         return startInfo;
     }
 
-    private void Marsify(ProcessStartInfo startInfo)
+    private void Marsify()
     {
         Log.Debug("Preparing patch assemblies.");
         FileHandler.PrepareMods();
 
-        ConfigureMarsey(startInfo);
+        ConfigureMarsey();
         MarseyCleanup();
     }
 
     // TODO: Make this a json or something like holy shit
     private string? _forkid;
     private string? _engine;
-    private void ConfigureMarsey(ProcessStartInfo startInfo)
+    private void ConfigureMarsey()
     {
-        // Logging
-        startInfo.EnvironmentVariables["MARSEY_LOADER_DEBUG"] = _cfg.GetCVar(CVars.LogLoaderDebug) ? "true" : null;
-        startInfo.EnvironmentVariables["MARSEY_LOGGING"] = _cfg.GetCVar(CVars.LogPatcher) ? "true" : null;
-        startInfo.EnvironmentVariables["MARSEY_SEPARATE_LOGGER"] = MarseyConf.SeparateLogger ? "true" : null;
-
-        // Safety
-        startInfo.EnvironmentVariables["MARSEY_THROW_FAIL"] = _cfg.GetCVar(CVars.ThrowPatchFail) ? "true" : null;
-        startInfo.EnvironmentVariables["MARSEY_HIDE_LEVEL"] = $"{_cfg.GetCVar(CVars.MarseyHide)}";
-        startInfo.EnvironmentVariables["MARSEY_JAMMER"] = _cfg.GetCVar(CVars.JamDials) ? "true" : null; // Redial
-        startInfo.EnvironmentVariables["MARSEY_DISABLE_REC"] = _cfg.GetCVar(CVars.Blackhole) ? "true" : null; // Remote Execute Command
-        startInfo.EnvironmentVariables["MARSEY_DISABLE_PRESENCE"] = _cfg.GetCVar(CVars.DisableRPC) ? "true" : null; // Hide discord RPC
-
-        // HWID
-        if (_cfg.GetCVar(CVars.ForcingHWId))
+        // Prepare environment variables
+        Dictionary<string, string?> envVars = new Dictionary<string, string?>
         {
-            startInfo.EnvironmentVariables["MARSEY_FORCINGHWID"] = "true";
-            startInfo.EnvironmentVariables["MARSEY_FORCEDHWID"] = MarseyGetHWID();
-        }
+            { "MARSEY_LOADER_DEBUG", _cfg.GetCVar(CVars.LogLoaderDebug) ? "true" : null },
+            { "MARSEY_LOGGING", _cfg.GetCVar(CVars.LogPatcher) ? "true" : null },
+            { "MARSEY_SEPARATE_LOGGER", MarseyConf.SeparateLogger ? "true" : null },
+            { "MARSEY_THROW_FAIL", _cfg.GetCVar(CVars.ThrowPatchFail) ? "true" : null },
+            { "MARSEY_HIDE_LEVEL", $"{_cfg.GetCVar(CVars.MarseyHide)}" },
+            { "MARSEY_JAMMER", _cfg.GetCVar(CVars.JamDials) ? "true" : null },
+            { "MARSEY_DISABLE_REC", _cfg.GetCVar(CVars.Blackhole) ? "true" : null },
+            { "MARSEY_DISABLE_PRESENCE", _cfg.GetCVar(CVars.DisableRPC) ? "true" : null },
+            { "MARSEY_FORCINGHWID", _cfg.GetCVar(CVars.ForcingHWId) ? "true" : null },
+            { "MARSEY_FORCEDHWID", _cfg.GetCVar(CVars.ForcingHWId) ? MarseyGetHWID() : null },
+            { "MARSEY_FORKID", _forkid },
+            { "MARSEY_ENGINE", _engine },
+            { "MARSEY_BACKPORTS", _cfg.GetCVar(CVars.Backports) ? "true" : null },
+            { "MARSEY_NO_ANY_BACKPORTS", _cfg.GetCVar(CVars.DisableAnyEngineBackports) ? "true" : null },
+            { "MARSEY_DISABLE_STRICT", _cfg.GetCVar(CVars.DisableStrict) ? "true" : null },
+            { "MARSEY_DUMP_ASSEMBLIES", MarseyConf.Dumper ? "true" : null }
+        };
 
-        // Data
-        startInfo.EnvironmentVariables["MARSEY_FORKID"] = _forkid;
-        startInfo.EnvironmentVariables["MARSEY_ENGINE"] = _engine;
+        // Serialize environment variables
+        string serializedEnvVars = string.Join(";", envVars.Select(kv => $"{kv.Key}={kv.Value}"));
 
-        // Backporter
-        startInfo.EnvironmentVariables["MARSEY_BACKPORTS"] = _cfg.GetCVar(CVars.Backports) ? "true" : null;
-        startInfo.EnvironmentVariables["MARSEY_NO_ANY_BACKPORTS"] =
-            _cfg.GetCVar(CVars.DisableAnyEngineBackports) ? "true" : null;
+        SendConfig(serializedEnvVars);
+    }
 
-        // ResPacks
-        startInfo.EnvironmentVariables["MARSEY_DISABLE_STRICT"] = _cfg.GetCVar(CVars.DisableStrict) ? "true" : null;
-        if (MarseyConf.Dumper)
-            startInfo.EnvironmentVariables["MARSEY_DUMP_ASSEMBLIES"] = "true";
+    private async Task SendConfig(string config)
+    {
+        Server MarseyConfPipeServer = new Server();
+        await MarseyConfPipeServer.ReadySend("MarseyConf", config);
     }
 
     private string MarseyGetHWID()
@@ -625,13 +626,14 @@ public class Connector : ReactiveObject
         string forcedHWID = _cfg.GetCVar(CVars.ForcedHWId);
         if (_cfg.GetCVar(CVars.RandHWID))
         {
-            forcedHWID = HWID.GenerateRandom(32);
+            forcedHWID = HWID.GenerateRandom();
         }
         else if (_cfg.GetCVar(CVars.LIHWIDBind))
         {
             forcedHWID = _loginManager.ActiveAccount!.LoginInfo.HWID;
         }
 
+        Log.Debug($"Exiting with {forcedHWID}");
         return forcedHWID;
     }
 

--- a/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
@@ -403,6 +403,7 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
                 Cfg.CommitConfig();
             }
 
+            OnPropertyChanged(nameof(HWIdString));
             return;
         }
 
@@ -411,7 +412,7 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
 
     private void OnGenHWIdClick()
     {
-        string hwid = HWID.GenerateRandom(32);
+        string hwid = HWID.GenerateRandom();
         _HWIdString = hwid;
         HWIdString = hwid;
 


### PR DESCRIPTION
Instead of envvar cancer its IPC cancer, and I dont have to worry about having 50 trillion envvars in startinfo because of it.
It's still 2 different dictionaries though
Also partial #18 due to RandHWID now showing you the generated HWID in the UI immediately.

Resolves #30.