### PR TITLE
Faking Discord RPC usernames

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Launcher-loader shared stuff -->
+    <PackageVersion Include="JetBrains.Annotations" Version="10.3.0" />
     <PackageVersion Include="Lib.Harmony" Version="2.3.0-prerelease.4" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="7.0.4" />
     <PackageVersion Include="MonoMod.Utils" Version="25.0.3" />

--- a/Marsey/Config/MarseyConf.cs
+++ b/Marsey/Config/MarseyConf.cs
@@ -43,8 +43,11 @@ public static class MarseyConf
     /// <see cref="HWID"/>
     public static bool ForceHWID;
 
-    /// <see cref="DiscordRPC"/>
+    /// <see cref="DiscordRPC.Disable"/>
     public static bool KillRPC;
+
+    /// <see cref="DiscordRPC.Fake"/>
+    public static bool FakeRPC;
 
     /// <see cref="Marsey.Game.Resources.Dumper.Dumper"/>
     public static bool Dumper;
@@ -66,6 +69,9 @@ public static class MarseyConf
     /// </summary>
     public static bool DisableAnyBackports;
 
+    /// <summary>
+    /// Reflect changes made here to the Dictionary in the launcher's Connector.cs
+    /// </summary>
     public static readonly Dictionary<string, Action<string>> EnvVarMap = new Dictionary<string, Action<string>>
     {
         { "MARSEY_LOGGING", value => Logging = value == "true" },
@@ -76,6 +82,8 @@ public static class MarseyConf
         { "MARSEY_FORCINGHWID", value => ForceHWID = value == "true" },
         { "MARSEY_FORCEDHWID", value => HWID.SetHWID(value)},
         { "MARSEY_DISABLE_PRESENCE", value => KillRPC = value == "true" },
+        { "MARSEY_FAKE_PRESENCE", value => FakeRPC = value == "true"},
+        { "MARSEY_PRESENCE_USERNAME", value => DiscordRPC.SetUsername(value)},
         { "MARSEY_DUMP_ASSEMBLIES", value => Dumper = value == "true" },
         { "MARSEY_JAMMER", value => JamDials = value == "true" },
         { "MARSEY_DISABLE_REC", value => DisableREC = value == "true" },

--- a/Marsey/Marsey.csproj
+++ b/Marsey/Marsey.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="JetBrains.Annotations" />
         <PackageReference Include="Lib.Harmony" />
         <PackageReference Include="Newtonsoft.Json" />
     </ItemGroup>

--- a/Marsey/Stealthsey/Hidesey.cs
+++ b/Marsey/Stealthsey/Hidesey.cs
@@ -123,7 +123,7 @@ public static class Hidesey
     public static void PostLoad()
     {
         HWID.Force();
-        DiscordRPC.Disable();
+        DiscordRPC.Patch();
 
         // Cleanup
         Disperse();

--- a/SS14.Launcher/Models/Connector.cs
+++ b/SS14.Launcher/Models/Connector.cs
@@ -599,6 +599,8 @@ public class Connector : ReactiveObject
             { "MARSEY_JAMMER", _cfg.GetCVar(CVars.JamDials) ? "true" : null },
             { "MARSEY_DISABLE_REC", _cfg.GetCVar(CVars.Blackhole) ? "true" : null },
             { "MARSEY_DISABLE_PRESENCE", _cfg.GetCVar(CVars.DisableRPC) ? "true" : null },
+            { "MARSEY_FAKE_PRESENCE", _cfg.GetCVar(CVars.FakeRPC) ? "true" : null },
+            { "MARSEY_PRESENCE_USERNAME", _cfg.GetCVar(CVars.RPCUsername) },
             { "MARSEY_FORCINGHWID", _cfg.GetCVar(CVars.ForcingHWId) ? "true" : null },
             { "MARSEY_FORCEDHWID", _cfg.GetCVar(CVars.ForcingHWId) ? MarseyGetHWID() : null },
             { "MARSEY_FORKID", _forkid },

--- a/SS14.Launcher/Models/Data/CVars.cs
+++ b/SS14.Launcher/Models/Data/CVars.cs
@@ -149,6 +149,16 @@ public static class CVars
     public static readonly CVarDef<bool> DisableRPC = CVarDef.Create("DisableRPC", false);
 
     /// <summary>
+    /// Do we fake the username on RPC?
+    /// </summary>
+    public static readonly CVarDef<bool> FakeRPC = CVarDef.Create("FakeRPC", false);
+
+    /// <summary>
+    /// Username to fake RPC with
+    /// </summary>
+    public static readonly CVarDef<string> RPCUsername = CVarDef.Create("RPCUsername", "");
+
+    /// <summary>
     /// Do we disable redialing?
     /// </summary>
     public static readonly CVarDef<bool> JamDials = CVarDef.Create("JamDials", false);

--- a/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
@@ -38,6 +38,7 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
     public ICommand GenHWIdCommand { get; }
     public ICommand DumpConfigCommand { get; }
     public ICommand SetUsernameCommand { get; }
+    public ICommand SetRPCUsernameCommand { get; }
     public ICommand SetGuestUsernameCommand { get; }
     public ICommand SetEndpointCommand { get; }
     public IEnumerable<HideLevel> HideLevels { get; } = Enum.GetValues(typeof(HideLevel)).Cast<HideLevel>();
@@ -52,6 +53,7 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
         _contentManager = Locator.Current.GetRequiredService<ContentManager>();
 
         SetHWIdCommand = new RelayCommand(OnSetHWIdClick);
+        SetRPCUsernameCommand = new RelayCommand(OnSetRPCUsernameClick);
         GenHWIdCommand = new RelayCommand(OnGenHWIdClick);
         SetUsernameCommand = new RelayCommand(OnSetUsernameClick);
         SetGuestUsernameCommand = new RelayCommand(OnSetGuestUsernameClick);
@@ -224,6 +226,24 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
             Cfg.SetCVar(CVars.DisableRPC, value);
             Cfg.CommitConfig();
         }
+    }
+
+    public bool FakeRPC
+    {
+        get => Cfg.GetCVar(CVars.FakeRPC);
+        set
+        {
+            Cfg.SetCVar(CVars.FakeRPC, value);
+            OnPropertyChanged(nameof(FakeRPC));
+            Cfg.CommitConfig();
+        }
+    }
+
+    private string _RPCUsername = "";
+    public string RPCUsername
+    {
+        get => Cfg.GetCVar(CVars.RPCUsername);
+        set => _RPCUsername = value;
     }
 
     public bool ForcingHWID
@@ -408,6 +428,12 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
         }
 
         Log.Warning("Passed HWId is not a valid hexadecimal string! Refusing to apply.");
+    }
+
+    private void OnSetRPCUsernameClick()
+    {
+        Cfg.SetCVar(CVars.RPCUsername, _RPCUsername);
+        Cfg.CommitConfig();
     }
 
     private void OnGenHWIdClick()

--- a/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
@@ -82,6 +82,19 @@
                        Text="Does not let Discord RPC initialize, hiding your username and server from your profile."
                        Margin="8" />
 
+            <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding FakeRPC}">Fake RPC Username</CheckBox>
+            <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
+                       Text="Changes the username on Discord Rich Presence."
+                       Margin="8" />
+
+            <Grid IsVisible="{Binding FakeRPC}" RowDefinitions="*, *, *" ColumnDefinitions="*, Auto">
+              <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Center" TextWrapping="NoWrap"
+                         Text="Set your username below. This username will be shown in the discord rich presence activity when hovering on the big icon."
+                         Margin="8"/>
+              <TextBox Grid.Row="1" Grid.Column="0" Width="600" MaxWidth="1000" HorizontalAlignment="Left" x:Name="RPCUsernameTextBox" VerticalAlignment="Center" Margin="4" Text="{Binding RPCUsername}"/>
+              <Button Grid.Row="2" Grid.Column="0" HorizontalAlignment="Left" Content="Set username" Command="{Binding SetRPCUsernameCommand}" VerticalAlignment="Center" Margin="4"/>
+            </Grid>
+
             <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding MarseyJam}">Disable Redial</CheckBox>
             <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
                        Text="Does not let game admins (or the game itself) to reconnect you to another station."


### PR DESCRIPTION
Ported from a patch to the launcher.
Allows **you** to set any username to appear on the Discord rich presence activity.
![image](https://github.com/ValidHunters/Marseyloader/assets/109166122/a17b7753-e6d8-4ba8-ac5b-8bf2c6240222)
