### PR TITLE
Add a flag to wait for debugger attachment in loader

### DIFF
--- a/Marsey/Config/MarseyConf.cs
+++ b/Marsey/Config/MarseyConf.cs
@@ -97,7 +97,7 @@ public static class MarseyConf
     // Conf variables that do not go into the EnvVarMap go here
 
     /// <summary>
-    /// Start a debugger in the loader process
+    /// Wait for a debugger to attach in the loader process before executing anything
     /// </summary>
     public static bool JumpLoaderDebug;
 }

--- a/Marsey/Config/MarseyConf.cs
+++ b/Marsey/Config/MarseyConf.cs
@@ -93,4 +93,11 @@ public static class MarseyConf
         { "MARSEY_ENGINE", MarseyPortMan.SetEngineVer },
         { "MARSEY_HIDE_LEVEL", value => MarseyHide = (HideLevel)Enum.Parse(typeof(HideLevel), value) }
     };
+
+    // Conf variables that do not go into the EnvVarMap go here
+
+    /// <summary>
+    /// Start a debugger in the loader process
+    /// </summary>
+    public static bool JumpLoaderDebug;
 }

--- a/Marsey/Misc/Utility.cs
+++ b/Marsey/Misc/Utility.cs
@@ -61,7 +61,7 @@ public static class MarseyLogger
 }
 public abstract class Utility
 {
-    private static bool CheckEnv(string envName)
+    public static bool CheckEnv(string envName)
     {
         string envVar = Envsey.CleanFlag(envName)!;
         return !string.IsNullOrEmpty(envVar) && bool.Parse(envVar);

--- a/Marsey/Stealthsey/Envsey.cs
+++ b/Marsey/Stealthsey/Envsey.cs
@@ -10,10 +10,9 @@ namespace Marsey.Stealthsey;
 public static class Envsey
 {
     /// <summary>
-    /// Sets an env variable to null
+    /// Gets the value of an env variable and then sets it to null
     /// </summary>
     /// <param name="envName">Name of env var</param>
-    [HideLevelRequirement(HideLevel.Normal)]
     public static string? CleanFlag(string envName)
     {
         string? temp = Environment.GetEnvironmentVariable(envName);

--- a/SS14.Launcher/LauncherCommands.cs
+++ b/SS14.Launcher/LauncherCommands.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Avalonia.Threading;
+using Marsey.Config;
 using Serilog;
 using Splat;
 using SS14.Launcher.Models.Data;
@@ -143,6 +144,11 @@ public class LauncherCommands
             cfg.SetCVar(CVars.MarseyApi, false);
             Log.Information("Marsey API has been disabled.");
         }
+        else if (cmd == DBGJumpCommand)
+        {
+            Log.Information("JUMPER ENABLED - Loader will wait for a debugger to attach!");
+            MarseyConf.JumpLoaderDebug = true;
+        }
         else if (cmd.StartsWith("R"))
         {
             // Reason (encoded in UTF-8 and then into hex for safety)
@@ -175,6 +181,7 @@ public class LauncherCommands
 
     public const string PingCommand = ":Ping";
     public const string DMApiCommand = ":DMAPI"; // Disable Marsey API
+    public const string DBGJumpCommand = ":Jumper";
     public const string RedialWaitCommand = ":RedialWait";
     public const string BlankReasonCommand = "r";
     public static string ConstructConnectCommand(Uri uri) => "c" + uri.ToString();

--- a/SS14.Launcher/Models/Connector.cs
+++ b/SS14.Launcher/Models/Connector.cs
@@ -476,6 +476,7 @@ public class Connector : ReactiveObject
         // Set other necessary environment variables.
         startInfo.EnvironmentVariables["SS14_DISABLE_SIGNING"] = _cfg.GetCVar(CVars.DisableSigning) ? "true" : null;
         startInfo.EnvironmentVariables["DOTNET_MULTILEVEL_LOOKUP"] = "0";
+        startInfo.EnvironmentVariables["MARSEY_JUMP_LOADER_DEBUG"] = MarseyConf.JumpLoaderDebug ? "true" : null;
     }
 
     private void ConfigureLogging(ProcessStartInfo startInfo)

--- a/SS14.Loader/Program.cs
+++ b/SS14.Loader/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
@@ -10,6 +11,7 @@ using System.Threading;
 using NSec.Cryptography;
 using Robust.LoaderApi;
 using Marsey;
+using Marsey.Misc;
 
 namespace SS14.Loader;
 
@@ -22,6 +24,8 @@ internal class Program
 
     private Program(string robustPath, string[] engineArgs)
     {
+        CheckDebugger();
+
         _engineArgs = engineArgs;
         var zipArchive = new ZipArchive(File.OpenRead(robustPath), ZipArchiveMode.Read);
 
@@ -35,6 +39,16 @@ internal class Program
         }
 
         _fileApi = new ZipFileApi(zipArchive, prefix);
+    }
+
+    private void CheckDebugger()
+    {
+        bool Jumper = Utility.CheckEnv("MARSEY_JUMP_LOADER_DEBUG");
+        if (!Jumper) return;
+
+        // Wait until debugger gets attached
+        while (!Debugger.IsAttached)
+            Thread.Sleep(100);;
     }
 
     private IntPtr LoadContextOnResolvingUnmanaged(Assembly assembly, string unmanaged)
@@ -61,7 +75,7 @@ internal class Program
         SQLitePCL.Batteries_V2.Init();
 
         ManualResetEvent mre = new ManualResetEvent(false);
-        
+
         // Start the MarseyPatcher
         MarseyPatcher.CreateInstance(clientAssembly, mre);
         mre.WaitOne();
@@ -81,7 +95,7 @@ internal class Program
         }
 
         var args = new MainArgs(_engineArgs, _fileApi, redialApi, extraMounts);
-        
+
         try
         {
             loader.Main(args);

--- a/SS14.Loader/Program.cs
+++ b/SS14.Loader/Program.cs
@@ -48,7 +48,7 @@ internal class Program
 
         // Wait until debugger gets attached
         while (!Debugger.IsAttached)
-            Thread.Sleep(100);;
+            Thread.Sleep(100);
     }
 
     private IntPtr LoadContextOnResolvingUnmanaged(Assembly assembly, string unmanaged)


### PR DESCRIPTION
Usage `--commands :Jumper`

Sets JumpLoaderDebug to true, which makes the loader wait until the debugger is attached before executing anything.