### PR TITLE
Redo on the patches view

### DIFF
--- a/Marsey/Config/MarseyVars.cs
+++ b/Marsey/Config/MarseyVars.cs
@@ -12,6 +12,8 @@ public static class MarseyVars
     // TODO: Kill this
     public static readonly Version MarseyVersion = new Version("2.17.0");
 
+    public static readonly string EnabledPatchListFileName = "patches.marsey";
+
     /// <summary>
     /// Default MarseyAPI endpoint url
     /// </summary>

--- a/SS14.Launcher/Marseyverse/DumpConfig.cs
+++ b/SS14.Launcher/Marseyverse/DumpConfig.cs
@@ -5,7 +5,7 @@ using Marsey.Config;
 using Marsey.Misc;
 using Serilog;
 
-namespace SS14.Launcher.MarseyFluff;
+namespace SS14.Launcher.Marseyverse;
 
 public static class DumpConfig
 {

--- a/SS14.Launcher/Marseyverse/Persist.cs
+++ b/SS14.Launcher/Marseyverse/Persist.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using Marsey.Config;
+
+namespace SS14.Launcher.Marseyverse;
+
+public static class Persist
+{
+    public static void SaveConfig(List<string> patches)
+    {
+        File.WriteAllLines(Path.Combine(LauncherPaths.DirUserData, MarseyVars.EnabledPatchListFileName), patches);
+    }
+
+    public static List<string> LoadConfig()
+    {
+        string filePath = Path.Combine(LauncherPaths.DirUserData, MarseyVars.EnabledPatchListFileName);
+        return File.Exists(filePath) ? [..File.ReadAllLines(filePath)] : [];
+    }
+}

--- a/SS14.Launcher/Marseyverse/TitleManager.cs
+++ b/SS14.Launcher/Marseyverse/TitleManager.cs
@@ -7,7 +7,7 @@ using Splat;
 using SS14.Launcher.Models.Data;
 using SS14.Launcher.Utility;
 
-namespace SS14.Launcher.MarseyFluff;
+namespace SS14.Launcher.Marseyverse;
 
 public class TitleCondition
 {
@@ -19,7 +19,7 @@ public class TitleManager
 {
     private const string BanMessage = "Banned";
     private static readonly Random Random = new Random();
-    
+
     public TitleManager()
     {
         DataManager cfg = Locator.Current.GetRequiredService<DataManager>(); // Thanks for inspiration.gif
@@ -35,13 +35,13 @@ public class TitleManager
             new TitleCondition { Condition = () => Subverter.GetSubverterPatches().Count > 5, Message = "Subversion is superior to git you know" },
             new TitleCondition { Condition = () => Marsyfier.GetMarseyPatches().Count > 10, Message = "Marsyfiedisms" }
         };
-        
+
         foreach (TitleCondition condition in titleConditions)
         {
             if (condition.Condition())
                 TagLines.Add(condition.Message);
         }
-        
+
         string name = RandTitle();
         string tagline = "";
 
@@ -52,7 +52,7 @@ public class TitleManager
 
         RandomTitle = name + ": " + tagline;
     }
-    
+
     private static readonly List<string> Titles =
     [
         "Space Station 14 Launcher", "Dramalauncher",
@@ -65,7 +65,7 @@ public class TitleManager
         "Stationeers", "RE:SS2D", "Schizostation 14",
         "Thaumatrauma", "Calamari v3", "hamaSS14", BanMessage
     ];
-    
+
     private static readonly List<string> TagLines =
     [
         "Marsey is the cutest cat", "Not a cheat loader",
@@ -105,7 +105,7 @@ public class TitleManager
         "No-appeal perma ban based on advice of the player and other hosts", "Metacomms", "\"soft antag rolling,\" powergaming, being rude in OOC",
         "Warned multiple times about powergaming as antag roles", "found to have been soft-antag rolling", "made the Janitor a furry against his will",
         "found to be displaying unhealthy investments in rounds based off of OOC/deadchat commentary", "Mass-RDM. Killed 31 people using electrified grilles",
-        "Openly bragging about being a shitter", "Posting fake porn links isn't funny", "3 bans in 6 months threshold", 
+        "Openly bragging about being a shitter", "Posting fake porn links isn't funny", "3 bans in 6 months threshold",
         "factors leading to a lot of attention seeking behavior", "Did nothing but plasmabomb med for 35 minutes",
         "asking people to do the thug shaker"
     ];

--- a/SS14.Launcher/ViewModels/ConnectingViewModel.cs
+++ b/SS14.Launcher/ViewModels/ConnectingViewModel.cs
@@ -5,7 +5,7 @@ using Marsey.Config;
 using Avalonia.Platform.Storage;
 using ReactiveUI;
 using Splat;
-using SS14.Launcher.MarseyFluff;
+using SS14.Launcher.Marseyverse;
 using SS14.Launcher.Models;
 using SS14.Launcher.Models.Data;
 using SS14.Launcher.Utility;

--- a/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
@@ -17,7 +17,7 @@ using Marsey.Stealthsey;
 using Microsoft.Toolkit.Mvvm.Input;
 using Serilog;
 using Splat;
-using SS14.Launcher.MarseyFluff;
+using SS14.Launcher.Marseyverse;
 using SS14.Launcher.Models.ContentManagement;
 using SS14.Launcher.Models.Data;
 using SS14.Launcher.Models.EngineManager;
@@ -303,6 +303,7 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
         {
             if (Latest == null) return false;
             int dist = MarseyVars.MarseyVersion.CompareTo(Marsey.API.MarseyApi.GetLatestVersion());
+            Marsey.API.MarseyApi.GetLatestVersion();
             return dist < 0;
         }
     }

--- a/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
@@ -303,7 +303,6 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
         {
             if (Latest == null) return false;
             int dist = MarseyVars.MarseyVersion.CompareTo(Marsey.API.MarseyApi.GetLatestVersion());
-            Marsey.API.MarseyApi.GetLatestVersion();
             return dist < 0;
         }
     }

--- a/SS14.Launcher/ViewModels/MainWindowViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowViewModel.cs
@@ -18,7 +18,7 @@ using ReactiveUI.Fody.Helpers;
 using Serilog;
 using Splat;
 using SS14.Launcher.Api;
-using SS14.Launcher.MarseyFluff;
+using SS14.Launcher.Marseyverse;
 using SS14.Launcher.Models;
 using SS14.Launcher.Models.Data;
 using SS14.Launcher.Models.Logins;

--- a/SS14.Launcher/Views/MainWindowTabs/PatchesTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/PatchesTabView.xaml
@@ -19,25 +19,34 @@
   <ScrollViewer HorizontalScrollBarVisibility="Disabled">
     <Grid RowDefinitions="Auto,*">
       <TabControl Grid.Row="0">
-        <TabItem Header="MarseyPatches">
+        <TabItem Header="Patches">
           <ScrollViewer HorizontalScrollBarVisibility="Disabled">
             <StackPanel>
-              <TextBlock Margin="4, 0" Text="Patches" Classes="NanoHeadingMedium" />
+              <TextBlock Margin="4, 0" Text="Marseys" Classes="NanoHeadingMedium" />
               <Separator/>
 
               <ItemsControl ItemsSource="{Binding MarseyPatches}" Name="MarseyPatchList">
+                <ItemsControl.ItemsPanel>
+                  <ItemsPanelTemplate>
+                    <WrapPanel Orientation="Horizontal" />
+                  </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                   <DataTemplate>
-                    <StackPanel Orientation="Horizontal">
-                      <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding Enabled}" Content="{Binding Name}"></CheckBox>
-                      <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
-                                 Text="{Binding Desc}"
-                                 Margin="8" />
-                      <TextBlock VerticalAlignment="Center" Margin="4" Foreground="Gray" Opacity="0.5"
-                                 Text="{Binding Preload, Converter={StaticResource BooleanToPreloadConverter}}"></TextBlock>
-                      <TextBlock VerticalAlignment="Center" Margin="4" Foreground="DimGray" Opacity="0.5"
-                                 Text="{Binding Asm.Location, Converter={StaticResource PathToFileNameConverter}}"></TextBlock>
-                    </StackPanel>
+                    <Grid Width="200" Margin="5">
+                      <ToggleButton
+                                    Command="{Binding DataContext.EnableRefreshCommand, ElementName=MarseyPatchList, FallbackValue={x:Null}}"
+                                    IsChecked="{Binding Enabled}"
+                                    Content="{Binding Name}">
+                        <ToolTip.Tip>
+                          <StackPanel>
+                            <TextBlock Text="{Binding Desc}" />
+                            <TextBlock Text="{Binding Asm.Location, Converter={StaticResource PathToFileNameConverter}}" Foreground="Gray"/>
+                            <TextBlock Text="{Binding Preload, Converter={StaticResource BooleanToPreloadConverter}}" IsVisible="{Binding Preload}"/>
+                          </StackPanel>
+                        </ToolTip.Tip>
+                      </ToggleButton>
+                    </Grid>
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>
               </ItemsControl>
@@ -45,23 +54,33 @@
           </ScrollViewer>
         </TabItem>
 
-        <TabItem Header="Subverter">
+        <TabItem Header="Sideloading">
           <ScrollViewer HorizontalScrollBarVisibility="Disabled">
             <StackPanel>
-              <TextBlock Margin="4, 0" Text="Sideloading" Classes="NanoHeadingMedium" />
+              <TextBlock Margin="4, 0" Text="Subversion" Classes="NanoHeadingMedium" />
               <Separator/>
 
               <ItemsControl ItemsSource="{Binding SubverterPatches}" Name="SubverterPatchList">
+                <ItemsControl.ItemsPanel>
+                  <ItemsPanelTemplate>
+                    <WrapPanel Orientation="Horizontal" />
+                  </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                   <DataTemplate>
-                    <StackPanel Orientation="Horizontal">
-                      <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding Enabled}" Content="{Binding Name}"></CheckBox>
-                      <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
-                                 Text="{Binding Desc}"
-                                 Margin="8" />
-                      <TextBlock VerticalAlignment="Center" Margin="4" Foreground="Gray" Opacity="0.5"
-                                 Text="{Binding Asm.Location, Converter={StaticResource PathToFileNameConverter}}"></TextBlock>
-                    </StackPanel>
+                    <Grid Width="200" Margin="5">
+                      <ToggleButton
+                                    Command="{Binding DataContext.EnableRefreshCommand, ElementName=SubverterPatchList, FallbackValue={x:Null}}"
+                                    IsChecked="{Binding Enabled}"
+                                    Content="{Binding Name}">
+                        <ToolTip.Tip>
+                          <StackPanel>
+                            <TextBlock Text="{Binding Desc}" />
+                            <TextBlock Text="{Binding Asm.Location, Converter={StaticResource PathToFileNameConverter}}" Foreground="Gray"/>
+                          </StackPanel>
+                        </ToolTip.Tip>
+                      </ToggleButton>
+                    </Grid>
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>
               </ItemsControl>
@@ -69,23 +88,31 @@
           </ScrollViewer>
         </TabItem>
 
-        <TabItem Header="ResourcePacks" IsVisible="{Binding ShowRPacks}">
+        <TabItem Header="Resources" IsVisible="{Binding ShowRPacks}">
           <ScrollViewer HorizontalScrollBarVisibility="Disabled">
             <StackPanel>
-              <TextBlock Margin="4, 0" Text="Patches" Classes="NanoHeadingMedium" />
+              <TextBlock Margin="4, 0" Text="Resource packs" Classes="NanoHeadingMedium" />
               <Separator/>
 
               <ItemsControl ItemsSource="{Binding ResourcePacks}" Name="ResourcePackList">
+                <ItemsControl.ItemsPanel>
+                  <ItemsPanelTemplate>
+                    <WrapPanel Orientation="Horizontal" />
+                  </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
                 <ItemsControl.ItemTemplate>
                   <DataTemplate>
-                    <StackPanel Orientation="Horizontal">
-                      <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding Enabled}" Content="{Binding Name}"></CheckBox>
-                      <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
-                                 Text="{Binding Desc}"
-                                 Margin="8" />
-                      <TextBlock VerticalAlignment="Center" Margin="4" Foreground="DimGray" Opacity="0.5"
-                                 Text="{Binding Dir, Converter={StaticResource PathToFileNameConverter}}"></TextBlock>
-                    </StackPanel>
+                    <Grid Width="200" Margin="5">
+                      <ToggleButton IsChecked="{Binding Enabled}"
+                                    Content="{Binding Name}">
+                        <ToolTip.Tip>
+                          <StackPanel>
+                            <TextBlock Text="{Binding Desc}" />
+                            <TextBlock Text="{Binding Dir, Converter={StaticResource PathToFileNameConverter}}" Foreground="Gray"/>
+                          </StackPanel>
+                        </ToolTip.Tip>
+                      </ToggleButton>
+                    </Grid>
                   </DataTemplate>
                 </ItemsControl.ItemTemplate>
               </ItemsControl>
@@ -102,3 +129,4 @@
     </Grid>
   </ScrollViewer>
 </UserControl>
+


### PR DESCRIPTION
The patches tab UI is now way more presentable
* Instead of a list with checkboxes - each mod is an individual button
* Descriptions and flags are part of the button's tooltip
![image](https://github.com/ValidHunters/Marseyloader/assets/109166122/0e435dee-77b1-423b-b1df-d0f927de8d58)

Resolves #29, enabled patches are saved across sessions