### PR TITLE
Fix locking up DLL's when launcher is open

### DIFF
--- a/Marsey/Config/MarseyConf.cs
+++ b/Marsey/Config/MarseyConf.cs
@@ -26,12 +26,12 @@ public static class MarseyConf
     public static bool Logging;
 
     /// <summary>
-    /// Log DBG messages
+    /// Log DEBG messages
     /// </summary>
     public static bool DebugAllowed;
 
     /// <summary>
-    /// Log TRC messages
+    /// Log TRCE messages
     /// </summary>
     public static bool TraceAllowed;
 

--- a/Marsey/Config/MarseyConf.cs
+++ b/Marsey/Config/MarseyConf.cs
@@ -26,9 +26,14 @@ public static class MarseyConf
     public static bool Logging;
 
     /// <summary>
-    /// Log DEBG messages
+    /// Log DBG messages
     /// </summary>
     public static bool DebugAllowed;
+
+    /// <summary>
+    /// Log TRC messages
+    /// </summary>
+    public static bool TraceAllowed;
 
     /// <summary>
     /// Throws an exception on client if any patch had failed applying.
@@ -76,6 +81,7 @@ public static class MarseyConf
     {
         { "MARSEY_LOGGING", value => Logging = value == "true" },
         { "MARSEY_LOADER_DEBUG", value => DebugAllowed = value == "true" },
+        { "MARSEY_LOADER_TRACE", value => TraceAllowed = value == "true" },
         { "MARSEY_THROW_FAIL", value => ThrowOnFail = value == "true" },
         { "MARSEY_SEPARATE_LOGGER", value => SeparateLogger = value == "true" },
         { "MARSEY_DISABLE_STRICT", value => DisableResPackStrict = value == "true" },

--- a/Marsey/Misc/FileHandler.cs
+++ b/Marsey/Misc/FileHandler.cs
@@ -90,6 +90,7 @@ public static async Task PrepareMods(string[]? path = null)
 
         foreach (string file in files)
         {
+            MarseyLogger.Log(MarseyLogger.LogType.DEBG, $"Loading assembly from {file}");
             LoadExactAssembly(file);
         }
     }
@@ -117,8 +118,9 @@ public static async Task PrepareMods(string[]? path = null)
 
         try
         {
-            Assembly assembly = Assembly.LoadFrom(file);
-            AssemblyInitializer.Initialize(assembly);
+            byte[] assemblyData = File.ReadAllBytes(file);
+            Assembly assembly = Assembly.Load(assemblyData);
+            AssemblyInitializer.Initialize(assembly, file);
         }
         catch (FileNotFoundException)
         {
@@ -137,7 +139,6 @@ public static async Task PrepareMods(string[]? path = null)
             Redial.Enable(); // Enable callbacks in case the game needs them
         }
     }
-
 
     /// <summary>
     /// Retrieves the file paths of all DLL files in a specified subdirectory

--- a/Marsey/Misc/Utility.cs
+++ b/Marsey/Misc/Utility.cs
@@ -15,7 +15,8 @@ public static class MarseyLogger
         WARN,
         ERRO,
         FATL,
-        DEBG
+        DEBG,
+        TRC
     }
 
     /// <summary>
@@ -36,10 +37,15 @@ public static class MarseyLogger
     /// </summary>
     public static void Log(LogType logType, string system, string message)
     {
-        if (logType == LogType.DEBG && MarseyConf.DebugAllowed != true)
-            return;
-
-        SharedLog($"[{logType.ToString()}] [{system}] {message}");
+        switch (logType)
+        {
+            case LogType.DEBG when MarseyConf.DebugAllowed != true:
+            case LogType.TRC when MarseyConf.TraceAllowed != true:
+                return;
+            default:
+                SharedLog($"[{logType.ToString()}] [{system}] {message}");
+                break;
+        }
     }
 
     /// <summary>

--- a/Marsey/Misc/Utility.cs
+++ b/Marsey/Misc/Utility.cs
@@ -16,7 +16,7 @@ public static class MarseyLogger
         ERRO,
         FATL,
         DEBG,
-        TRC
+        TRCE
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ public static class MarseyLogger
         switch (logType)
         {
             case LogType.DEBG when MarseyConf.DebugAllowed != true:
-            case LogType.TRC when MarseyConf.TraceAllowed != true:
+            case LogType.TRCE when MarseyConf.TraceAllowed != true:
                 return;
             default:
                 SharedLog($"[{logType.ToString()}] [{system}] {message}");

--- a/Marsey/PatchAssembly/AssemblyInitializer.cs
+++ b/Marsey/PatchAssembly/AssemblyInitializer.cs
@@ -54,7 +54,7 @@ public static class AssemblyInitializer
         bool ignore = AssemblyFieldHandler.DetermineIgnore(dataType);
         List<FieldInfo>? targets = null;
 
-        MarseyLogger.Log(MarseyLogger.LogType.TRC, "AssemblyInitializer", $"Processing {assemblyName}, preload: {preload}, ignore: {ignore}");
+        MarseyLogger.Log(MarseyLogger.LogType.TRCE, "AssemblyInitializer", $"Processing {assemblyName}, preload: {preload}, ignore: {ignore}");
 
         if (typeName == "MarseyPatch")
         {
@@ -101,7 +101,7 @@ public static class AssemblyInitializer
         // Check if its even valid
         if (!PatchFactory.TryGetValue(dataType.Name, out Func<Assembly, string, string, string, bool, IPatch>? createPatch)) return;
 
-        MarseyLogger.Log(MarseyLogger.LogType.TRC, "AssemblyInitializer", $"{assembly.GetName()} passed PatchFactory validation");
+        MarseyLogger.Log(MarseyLogger.LogType.TRCE, "AssemblyInitializer", $"{assembly.GetName()} passed PatchFactory validation");
 
         Hidesey.HidePatch(assembly); // Conceal assembly from the game
 

--- a/Marsey/PatchAssembly/AssemblyInitializer.cs
+++ b/Marsey/PatchAssembly/AssemblyInitializer.cs
@@ -11,21 +11,22 @@ namespace Marsey.PatchAssembly;
 /// </summary>
 public static class AssemblyInitializer
 {
-    private static readonly Dictionary<string, Func<Assembly, string, string, bool, IPatch>> PatchFactory =
-        new Dictionary<string, Func<Assembly, string, string, bool, IPatch>>
+    private static readonly Dictionary<string, Func<Assembly, string, string, string, bool, IPatch>> PatchFactory =
+        new Dictionary<string, Func<Assembly, string, string, string, bool, IPatch>>
         {
-            { "MarseyPatch", (assembly, name, description, preloadField) => new MarseyPatch(assembly.Location, assembly, name, description, preloadField) },
-            { "SubverterPatch", (assembly, name, description, preloadField) => new SubverterPatch(assembly.Location, assembly, name, description) }
+            { "MarseyPatch", (assembly, assemblyLocation, name, description, preloadField) => new MarseyPatch(assemblyLocation, assembly, name, description, preloadField) },
+            { "SubverterPatch", (assembly, assemblyLocation, name, description, preloadField) => new SubverterPatch(assemblyLocation, assembly, name, description) }
         };
 
-    public static void Initialize(Assembly assembly)
+
+    public static void Initialize(Assembly assembly, string path)
     {
         ArgumentNullException.ThrowIfNull(assembly);
 
         Type? dataType = GetDataType(assembly);
         if (dataType == null) return;
 
-        ProcessDataType(assembly, dataType);
+        ProcessDataType(assembly, dataType, path);
     }
 
     private static Type? GetDataType(Assembly assembly)
@@ -45,13 +46,15 @@ public static class AssemblyInitializer
         }
     }
 
-    private static void ProcessDataType(Assembly assembly, Type dataType)
+    private static void ProcessDataType(Assembly assembly, Type dataType, string path)
     {
         string typeName = dataType.Name;
         string? assemblyName = assembly.GetName().Name;
         bool preload = AssemblyFieldHandler.DeterminePreload(dataType);
         bool ignore = AssemblyFieldHandler.DetermineIgnore(dataType);
         List<FieldInfo>? targets = null;
+
+        MarseyLogger.Log(MarseyLogger.LogType.TRC, "AssemblyInitializer", $"Processing {assemblyName}, preload: {preload}, ignore: {ignore}");
 
         if (typeName == "MarseyPatch")
         {
@@ -87,20 +90,22 @@ public static class AssemblyInitializer
         // Retrieve additional fields such as name and description from the data type
         AssemblyFieldHandler.GetFields(dataType, out string name, out string description);
         // Attempt to create and add a patch to the assembly with the retrieved information
-        TryCreateAddPatch(assembly, dataType, name, description, preload);
+        TryCreateAddPatch(assembly, dataType, path, name, description, preload);
     }
 
 
-    private static void TryCreateAddPatch(Assembly assembly, MemberInfo? dataType, string name, string description, bool preloadField)
+    private static void TryCreateAddPatch(Assembly assembly, MemberInfo? dataType, string path, string name, string description, bool preloadField)
     {
         if (dataType == null) return;
 
         // Check if its even valid
-        if (!PatchFactory.TryGetValue(dataType.Name, out Func<Assembly, string, string, bool, IPatch>? createPatch)) return;
+        if (!PatchFactory.TryGetValue(dataType.Name, out Func<Assembly, string, string, string, bool, IPatch>? createPatch)) return;
+
+        MarseyLogger.Log(MarseyLogger.LogType.TRC, "AssemblyInitializer", $"{assembly.GetName()} passed PatchFactory validation");
 
         Hidesey.HidePatch(assembly); // Conceal assembly from the game
 
-        IPatch patch = createPatch(assembly, name, description, preloadField);
+        IPatch patch = createPatch(assembly, path, name, description, preloadField);
         PatchListManager.AddPatchToList(patch);
     }
 }

--- a/Marsey/PatchAssembly/PatchListManager.cs
+++ b/Marsey/PatchAssembly/PatchListManager.cs
@@ -34,7 +34,7 @@ public static class PatchListManager
     {
         if (_patches.Any(p => p.Asmpath == patch.Asmpath)) return;
 
-        MarseyLogger.Log(MarseyLogger.LogType.TRC, $"Adding {patch.Name} ({patch.Asmpath}) to patchlist");
+        MarseyLogger.Log(MarseyLogger.LogType.TRCE, $"Adding {patch.Name} ({patch.Asmpath}) to patchlist");
         _patches.Add(patch);
     }
 

--- a/Marsey/PatchAssembly/PatchListManager.cs
+++ b/Marsey/PatchAssembly/PatchListManager.cs
@@ -34,6 +34,7 @@ public static class PatchListManager
     {
         if (_patches.Any(p => p.Asmpath == patch.Asmpath)) return;
 
+        MarseyLogger.Log(MarseyLogger.LogType.TRC, $"Adding {patch.Name} ({patch.Asmpath}) to patchlist");
         _patches.Add(patch);
     }
 

--- a/SS14.Launcher/Marseyverse/Persist.cs
+++ b/SS14.Launcher/Marseyverse/Persist.cs
@@ -1,19 +1,31 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using Marsey.Config;
+using Splat;
+using SS14.Launcher.Models.Data;
+using SS14.Launcher.Utility;
 
 namespace SS14.Launcher.Marseyverse;
 
 public static class Persist
 {
-    public static void SaveConfig(List<string> patches)
+    public static void SavePatchlistConfig(List<string> patches)
     {
         File.WriteAllLines(Path.Combine(LauncherPaths.DirUserData, MarseyVars.EnabledPatchListFileName), patches);
     }
 
-    public static List<string> LoadConfig()
+    public static List<string> LoadPatchlistConfig()
     {
         string filePath = Path.Combine(LauncherPaths.DirUserData, MarseyVars.EnabledPatchListFileName);
         return File.Exists(filePath) ? [..File.ReadAllLines(filePath)] : [];
+    }
+
+    public static void UpdateLauncherConfig()
+    {
+        DataManager cfg = Locator.Current.GetRequiredService<DataManager>();
+
+        MarseyConf.Logging = cfg.GetCVar(CVars.LogLauncherPatcher);
+        MarseyConf.DebugAllowed = cfg.GetCVar(CVars.LogLoaderDebug);
+        MarseyConf.TraceAllowed = cfg.GetCVar(CVars.LogLoaderTrace);
     }
 }

--- a/SS14.Launcher/Models/Connector.cs
+++ b/SS14.Launcher/Models/Connector.cs
@@ -593,8 +593,9 @@ public class Connector : ReactiveObject
         // Prepare environment variables
         Dictionary<string, string?> envVars = new Dictionary<string, string?>
         {
-            { "MARSEY_LOADER_DEBUG", _cfg.GetCVar(CVars.LogLoaderDebug) ? "true" : null },
             { "MARSEY_LOGGING", _cfg.GetCVar(CVars.LogPatcher) ? "true" : null },
+            { "MARSEY_LOADER_DEBUG", _cfg.GetCVar(CVars.LogLoaderDebug) ? "true" : null },
+            { "MARSEY_LOADER_TRACE", _cfg.GetCVar(CVars.LogLoaderTrace) ? "true" : null },
             { "MARSEY_SEPARATE_LOGGER", _cfg.GetCVar(CVars.LogPatcher) ? "true" : null },
             { "MARSEY_THROW_FAIL", _cfg.GetCVar(CVars.ThrowPatchFail) ? "true" : null },
             { "MARSEY_HIDE_LEVEL", $"{_cfg.GetCVar(CVars.MarseyHide)}" },

--- a/SS14.Launcher/Models/Data/CVars.cs
+++ b/SS14.Launcher/Models/Data/CVars.cs
@@ -136,6 +136,17 @@ public static class CVars
     /// </summary>
     public static readonly CVarDef<bool> SeparateLogging = CVarDef.Create("SeparateLogging", false);
 
+    /// <summary>
+    /// Log patcher output in launcher
+    /// </summary>
+    public static readonly CVarDef<bool> LogLauncherPatcher = CVarDef.Create("LogLauncherPatcher", false);
+
+    /// <summary>
+    /// Log TRC messages
+    /// </summary>
+    /// <remarks>Hidden behind the debug compile flag</remarks>
+    public static readonly CVarDef<bool> LogLoaderTrace = CVarDef.Create("LogLoaderTrace", false);
+
     // Behavior
 
     /// <summary>

--- a/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
@@ -59,6 +59,8 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
         SetGuestUsernameCommand = new RelayCommand(OnSetGuestUsernameClick);
         SetEndpointCommand = new RelayCommand(OnSetEndpointClick);
         DumpConfigCommand = new RelayCommand(DumpConfig.Dump);
+
+        Persist.UpdateLauncherConfig();
     }
 
 #if RELEASE
@@ -129,6 +131,18 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
         }
     }
 
+    public bool LogLauncherPatcher
+    {
+        get => Cfg.GetCVar(CVars.LogLauncherPatcher);
+        set
+        {
+            Cfg.SetCVar(CVars.LogLauncherPatcher, value);
+            Cfg.CommitConfig();
+
+            Persist.UpdateLauncherConfig();
+        }
+    }
+
     public bool LogLoaderDebug
     {
         get => Cfg.GetCVar(CVars.LogLoaderDebug);
@@ -136,6 +150,20 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
         {
             Cfg.SetCVar(CVars.LogLoaderDebug, value);
             Cfg.CommitConfig();
+
+            Persist.UpdateLauncherConfig();
+        }
+    }
+
+    public bool LogTrace
+    {
+        get => Cfg.GetCVar(CVars.LogLoaderTrace);
+        set
+        {
+            Cfg.SetCVar(CVars.LogLoaderTrace, value);
+            Cfg.CommitConfig();
+
+            Persist.UpdateLauncherConfig();
         }
     }
 

--- a/SS14.Launcher/ViewModels/MainWindowTabs/PatchesTabViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/PatchesTabViewModel.cs
@@ -70,7 +70,7 @@ namespace SS14.Launcher.ViewModels.MainWindowTabs
 
         private void EnableConfiguredPatches()
         {
-            List<string> assemblies = Persist.LoadConfig();
+            List<string> assemblies = Persist.LoadPatchlistConfig();
             LoadEnabledPatches(assemblies, MarseyPatches);
             LoadEnabledPatches(assemblies, SubverterPatches);
         }
@@ -113,7 +113,7 @@ namespace SS14.Launcher.ViewModels.MainWindowTabs
             SaveEnabledPatches(SubverterPatches, assemblyFileNames);
 
             Log.Debug($"Saved {assemblyFileNames.Count} patches to config");
-            Persist.SaveConfig(assemblyFileNames);
+            Persist.SavePatchlistConfig(assemblyFileNames);
         }
 
         private void SaveEnabledPatches(IEnumerable<IPatch> patches, List<string> fileNames)

--- a/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
@@ -182,6 +182,8 @@
         <DockPanel>
           <StackPanel Orientation="Vertical">
             <TextBlock Margin="4, 0" Text="Game" Classes="NanoHeadingMedium" />
+            <Button Content="Open log directory" DockPanel.Dock="Bottom" HorizontalAlignment="Left"
+                    Command="{Binding OpenLogDirectory}"/>
             <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding LogClient}">Log Client</CheckBox>
             <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
                        Text="Enables logging of any game client output. Useful for developers."
@@ -197,18 +199,24 @@
                        Text="For when the developers are *very* stumped with your problem. (requires launcher restart)"
                        Margin="8" />
 
-            <Button Content="Open log directory" DockPanel.Dock="Bottom" HorizontalAlignment="Left"
-                    Command="{Binding OpenLogDirectory}"/>
-
-            <TextBlock Margin="4, 0" Text="Patcher" Classes="NanoHeadingMedium" />
             <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding LogPatches}">Log Patcher</CheckBox>
             <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
                        Text="Write MarseyLogger output to log."
                        Margin="8" />
 
+            <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding LogLauncherPatcher}">Enable launcher-patcher logging</CheckBox>
+            <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
+                       Text="Write MarseyLogger output to launcher's stdout."
+                       Margin="8" />
+
             <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding LogLoaderDebug}">Enable Loader Debug Logs</CheckBox>
             <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
                        Text="Enable harmony debug mode, outputting IL code to desktop and providing marsey debug logs."
+                       Margin="8" />
+
+            <CheckBox VerticalAlignment="Center" Margin="4" IsVisible="{Binding !HideDebugKnobs}" IsChecked="{Binding LogTrace}">Log Trace MarseyLogger messages</CheckBox>
+            <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
+                       Text="Write MarseyLogger trace logs to stdout."
                        Margin="8" />
 
             <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding SeparateLogging}">Separate Game/Patcher Logs</CheckBox>


### PR DESCRIPTION
Instead of directly loading from file - read data of the file and create a new assembly from that.
Also adds trace logs for developer debugging
Also adds the ability to get marsey logs in launcher stdout

Resolves #40 