### PR TITLE
Allow subversion patches to hide themselves on demand

### DIFF
--- a/Marsey/Subversion/Sedition.cs
+++ b/Marsey/Subversion/Sedition.cs
@@ -15,19 +15,19 @@ public static class Sedition
         Hidesey.HidePatch(asm);
     }
 
-    public static void InitHidesey(Assembly assembly, string? assemblyName)
+    public static void InitSedition(Assembly assembly, string? assemblyName)
     {
-        Type? hideseyType = assembly.GetType("Hidesey");
+        Type? hideseyType = assembly.GetType("Sedition");
         if (hideseyType == null)
         {
             MarseyLogger.Log(MarseyLogger.LogType.DEBG, $"{assemblyName} has no Hidesey class");
             return;
         }
 
-        SetupHidesey(hideseyType);
+        SetupSedition(hideseyType);
     }
 
-    private static void SetupHidesey(Type hidesey)
+    private static void SetupSedition(Type hidesey)
     {
         MethodInfo? stealthseyHide =
             typeof(Sedition).GetMethod("HideDelegate", BindingFlags.Static | BindingFlags.NonPublic);
@@ -35,7 +35,7 @@ public static class Sedition
 
         if (asmHideseyDelegate == null || stealthseyHide == null)
         {
-            MarseyLogger.Log(MarseyLogger.LogType.ERRO, $"Missing delegate fields on hidesey");
+            MarseyLogger.Log(MarseyLogger.LogType.ERRO, $"Missing delegate fields on sedition");
             return;
         }
 
@@ -46,7 +46,7 @@ public static class Sedition
         }
         catch (Exception e)
         {
-            MarseyLogger.Log(MarseyLogger.LogType.FATL, $"Failed to to assign logger delegate: {e.Message}");
+            MarseyLogger.Log(MarseyLogger.LogType.FATL, $"Failed to to assign sedition delegate: {e.Message}");
         }
     }
 }

--- a/Marsey/Subversion/Sedition.cs
+++ b/Marsey/Subversion/Sedition.cs
@@ -1,0 +1,52 @@
+﻿using System.Reflection;
+using Marsey.Misc;
+using Marsey.Stealthsey;
+
+namespace Marsey.Subversion;
+
+/// <summary>
+///     Manages Hidesey patch helper class
+/// </summary>
+public static class Sedition
+{
+    private static void HideDelegate(Assembly asm)
+    {
+        MarseyLogger.Log(MarseyLogger.LogType.DEBG, "Hiding");
+        Hidesey.HidePatch(asm);
+    }
+
+    public static void InitHidesey(Assembly assembly, string? assemblyName)
+    {
+        Type? hideseyType = assembly.GetType("Hidesey");
+        if (hideseyType == null)
+        {
+            MarseyLogger.Log(MarseyLogger.LogType.DEBG, $"{assemblyName} has no Hidesey class");
+            return;
+        }
+
+        SetupHidesey(hideseyType);
+    }
+
+    private static void SetupHidesey(Type hidesey)
+    {
+        MethodInfo? stealthseyHide =
+            typeof(Sedition).GetMethod("HideDelegate", BindingFlags.Static | BindingFlags.NonPublic);
+        FieldInfo? asmHideseyDelegate = hidesey.GetField("hideDelegate", BindingFlags.Public | BindingFlags.Static);
+
+        if (asmHideseyDelegate == null || stealthseyHide == null)
+        {
+            MarseyLogger.Log(MarseyLogger.LogType.ERRO, $"Missing delegate fields on hidesey");
+            return;
+        }
+
+        try
+        {
+            Delegate logDelegate = Delegate.CreateDelegate(asmHideseyDelegate.FieldType, stealthseyHide);
+            asmHideseyDelegate.SetValue(null, logDelegate);
+        }
+        catch (Exception e)
+        {
+            MarseyLogger.Log(MarseyLogger.LogType.FATL, $"Failed to to assign logger delegate: {e.Message}");
+        }
+    }
+}

--- a/Marsey/Subversion/Subverse.cs
+++ b/Marsey/Subversion/Subverse.cs
@@ -61,6 +61,7 @@ public static class Subverse
             Assembly subverterAssembly = Assembly.LoadFrom(path);
             MarseyLogger.Log(MarseyLogger.LogType.DEBG, "Subversion", $"Sideloading {path}");
             AssemblyFieldHandler.InitLogger(subverterAssembly, subverterAssembly.FullName);
+            Sedition.InitHidesey(subverterAssembly, subverterAssembly.FullName);
 
             loadGameAssemblyMethod.Invoke(__instance, new object[] { subverterAssembly });
 

--- a/Marsey/Subversion/Subverse.cs
+++ b/Marsey/Subversion/Subverse.cs
@@ -61,7 +61,7 @@ public static class Subverse
             Assembly subverterAssembly = Assembly.LoadFrom(path);
             MarseyLogger.Log(MarseyLogger.LogType.DEBG, "Subversion", $"Sideloading {path}");
             AssemblyFieldHandler.InitLogger(subverterAssembly, subverterAssembly.FullName);
-            Sedition.InitHidesey(subverterAssembly, subverterAssembly.FullName);
+            Sedition.InitSedition(subverterAssembly, subverterAssembly.FullName);
 
             loadGameAssemblyMethod.Invoke(__instance, new object[] { subverterAssembly });
 


### PR DESCRIPTION
Usage:

```
// No namespace

public static class Sedition
{
    private static bool tripped = false;
    
    public delegate void Forward(Assembly asm);

    public static Forward? hideDelegate;

    public static void Hide()
    {
        if (tripped) return;

        tripped = true;
        hideDelegate?.Invoke(Assembly.GetExecutingAssembly());
    }
}
```
Ideally attach a call to Hide after the Init entrypoint function

Resolves #31 