### PR TITLE
Initial support for hwid2

### DIFF
--- a/Marsey/Config/MarseyConf.cs
+++ b/Marsey/Config/MarseyConf.cs
@@ -75,6 +75,11 @@ public static class MarseyConf
     public static bool DisableAnyBackports;
 
     /// <summary>
+    /// Don't run any patches
+    /// </summary>
+    public static bool Patchless;
+
+    /// <summary>
     /// Reflect changes made here to the Dictionary in the launcher's Connector.cs
     /// </summary>
     public static readonly Dictionary<string, Action<string>> EnvVarMap = new Dictionary<string, Action<string>>
@@ -97,7 +102,8 @@ public static class MarseyConf
         { "MARSEY_NO_ANY_BACKPORTS", value => DisableAnyBackports = value == "true" },
         { "MARSEY_FORKID", MarseyPortMan.SetForkID },
         { "MARSEY_ENGINE", MarseyPortMan.SetEngineVer },
-        { "MARSEY_HIDE_LEVEL", value => MarseyHide = (HideLevel)Enum.Parse(typeof(HideLevel), value) }
+        { "MARSEY_HIDE_LEVEL", value => MarseyHide = (HideLevel)Enum.Parse(typeof(HideLevel), value) },
+        { "MARSEY_PATCHLESS", value => Patchless = value == "true"}
     };
 
     // Conf variables that do not go into the EnvVarMap go here

--- a/Marsey/Game/Patcher.cs
+++ b/Marsey/Game/Patcher.cs
@@ -7,6 +7,7 @@ using Marsey.Game.Managers;
 using Marsey.Game.Misc;
 using Marsey.Patches;
 using Marsey.Misc;
+using Marsey.Stealthsey.Reflection;
 
 namespace Marsey.Game;
 
@@ -25,9 +26,10 @@ public static class Patcher
             PatchAssembly(harmony, patch);
         }
     }
-    
+
     /// <inheritdoc cref="Patcher.Patch"/>
-    private static void PatchAssembly<T>(Harmony harmony, T patch) where T : IPatch
+    [Patching]
+    private static void PatchAssembly(Harmony harmony, IPatch patch)
     {
         AssemblyName assemblyName = patch.Asm.GetName();
         MarseyLogger.Log(MarseyLogger.LogType.INFO, $"Patching {assemblyName}");

--- a/Marsey/Game/Patches/Marseyports/MarseyPortMan.cs
+++ b/Marsey/Game/Patches/Marseyports/MarseyPortMan.cs
@@ -5,6 +5,7 @@ using Marsey.Config;
 using Marsey.Game.Patches.Marseyports.Attributes;
 using Marsey.Misc;
 using Marsey.Stealthsey;
+using Marsey.Stealthsey.Reflection;
 
 namespace Marsey.Game.Patches.Marseyports;
 
@@ -66,6 +67,7 @@ public static class MarseyPortMan
         return true;
     }
 
+    [Patching]
     public static void PatchBackports(bool Content = false)
     {
         if (_backports == null) return;

--- a/Marsey/MarseyPatcher.cs
+++ b/Marsey/MarseyPatcher.cs
@@ -15,6 +15,7 @@ using Marsey.Patches;
 using Marsey.Stealthsey;
 using Marsey.Subversion;
 using Marsey.Misc;
+using Marsey.Stealthsey.Reflection;
 
 namespace Marsey;
 
@@ -63,7 +64,7 @@ public class MarseyPatcher
         Utility.ReadConf();
         HarmonyManager.Init(new Harmony(MarseyVars.Identifier));
 
-        MarseyLogger.Log(MarseyLogger.LogType.INFO, $"Marseyloader started, version {MarseyVars.MarseyVersion}");
+        MarseyLogger.Log(MarseyLogger.LogType.INFO, $"Marseyloader started{(MarseyConf.Patchless ? " in patchless mode" : "")}, version {MarseyVars.MarseyVersion}");
 
         // Init backport manager
         MarseyPortMan.Initialize();
@@ -78,7 +79,8 @@ public class MarseyPatcher
     }
 
     // We might want to patch things before the loader has even a chance to execute anything
-    public void Preload()
+    [Patching]
+    private void Preload()
     {
         Sentry.Patch();
 

--- a/Marsey/Stealthsey/Hidesey.cs
+++ b/Marsey/Stealthsey/Hidesey.cs
@@ -73,7 +73,7 @@ public static class Hidesey
 
         _initialized = true;
 
-        HideLevelExec.Initialize();
+        HideseyAttributeManager.Initialize();
 
         Load();
     }
@@ -203,7 +203,7 @@ public static class Hidesey
             Helpers.PatchGenericMethod(
                 target: targetMethod,
                 patch: Lie,
-                returnType: returnType,
+                patchReturnType: returnType,
                 patchType: HarmonyPatchType.Postfix
             );
         }

--- a/Marsey/Stealthsey/HideseyPatches.cs
+++ b/Marsey/Stealthsey/HideseyPatches.cs
@@ -34,6 +34,8 @@ public static class HideseyPatches
     /// </summary>
     public static bool Skip() => false;
 
+    public static bool SkipPatchless() => !MarseyConf.Patchless;
+
     /// <summary>
     /// Prefix patch that checks if MarseyHide matches or above the attributed HideLevelRequirement
     /// </summary>

--- a/Marsey/Stealthsey/Reflection/HideseyAttributeManager.cs
+++ b/Marsey/Stealthsey/Reflection/HideseyAttributeManager.cs
@@ -64,12 +64,8 @@ public static class HideseyAttributeManager
         if (method.GetCustomAttribute<Patching>() is null) return;
         if (method.IsGenericMethod) throw new InvalidOperationException("Patching attribute not allowed on generic methods.");
 
-        Console.WriteLine($"Trying to patch {method.Name}");
-
         MethodInfo? prefix = AccessTools.Method(typeof(HideseyPatches), nameof(HideseyPatches.SkipPatchless));
 
         Manual.Patch(method, prefix, HarmonyPatchType.Prefix);
-
-        Console.WriteLine($"Patched {method.Name} fine");
     }
 }

--- a/Marsey/Stealthsey/Reflection/HideseyAttributeManager.cs
+++ b/Marsey/Stealthsey/Reflection/HideseyAttributeManager.cs
@@ -12,7 +12,7 @@ namespace Marsey.Stealthsey.Reflection;
 /// <summary>
 /// Manages methods with the HideLevelRequirement attribute, patching them with a prefix.
 /// </summary>
-public static class HideLevelExec
+public static class HideseyAttributeManager
 {
     /// <summary>
     /// Initializes the HideLevelExec by finding and patching methods with HideLevelRequirement attributes.
@@ -21,40 +21,55 @@ public static class HideLevelExec
     {
         Assembly assembly = Assembly.GetExecutingAssembly();
         IEnumerable<Type> types = assembly.GetTypes();
-        
-        IEnumerable<Type> marseyTypes = types.Where(t => t.Namespace != null && t.Namespace.StartsWith("Marsey"));
-        
+
+        IEnumerable<Type> marseyTypes = Assembly.GetExecutingAssembly().ExportedTypes;
+
         foreach (Type type in marseyTypes)
         {
             CheckAndExecute(type);
         }
     }
-    
+
     /// <summary>
     /// Checks each type for methods with HideLevelRequirement attributes and executes them if the hide level is met.
     /// </summary>
     private static void CheckAndExecute(Type type)
     {
         // Get all methods from the given type
-        IEnumerable<MethodInfo> methods = type.GetMethods(BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Public | BindingFlags.Instance);
+        IEnumerable<MethodInfo> methods = AccessTools.GetDeclaredMethods(type);
 
         foreach (MethodInfo method in methods)
         {
-            ExecIfLevelMet(method);
+            SetExecLevels(method);
+            SetPatchless(method);
         }
     }
-    
+
     /// <summary>
     /// Executes the method if the current hide level meets or exceeds the required level specified by the HideLevelRequirement attribute.
     /// </summary>
-    private static void ExecIfLevelMet(MethodInfo method)
+    private static void SetExecLevels(MethodInfo method)
     {
         HideLevelRequirement? hideLevelRequirement = method.GetCustomAttribute<HideLevelRequirement>();
         HideLevelRestriction? hideLevelRestriction = method.GetCustomAttribute<HideLevelRestriction>();
 
         if (hideLevelRequirement == null && hideLevelRestriction == null) return;
-        
+
         MethodInfo? prefix = typeof(HideseyPatches).GetMethod("LevelCheck", BindingFlags.Public | BindingFlags.Static);
         Manual.Patch(method, prefix, HarmonyPatchType.Prefix);
+    }
+
+    private static void SetPatchless(MethodInfo method)
+    {
+        if (method.GetCustomAttribute<Patching>() is null) return;
+        if (method.IsGenericMethod) throw new InvalidOperationException("Patching attribute not allowed on generic methods.");
+
+        Console.WriteLine($"Trying to patch {method.Name}");
+
+        MethodInfo? prefix = AccessTools.Method(typeof(HideseyPatches), nameof(HideseyPatches.SkipPatchless));
+
+        Manual.Patch(method, prefix, HarmonyPatchType.Prefix);
+
+        Console.WriteLine($"Patched {method.Name} fine");
     }
 }

--- a/Marsey/Stealthsey/Reflection/PatchingAttribute.cs
+++ b/Marsey/Stealthsey/Reflection/PatchingAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System.Reflection;
+
+namespace Marsey.Stealthsey.Reflection;
+
+/// <summary>
+/// Method is patching the game in some form
+/// <remarks> Does not execute if <see cref="Patching"/> is true </remarks>
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+public sealed class Patching : Attribute;

--- a/Marsey/Subversion/Subverse.cs
+++ b/Marsey/Subversion/Subverse.cs
@@ -32,6 +32,7 @@ public static class Subverse
     /// This is done as we attach to the assembly loading function
     /// </summary>
     [HideLevelRestriction(HideLevel.Unconditional)]
+    [Patching]
     public static void PatchSubverter()
     {
 

--- a/SS14.Launcher/Models/Connector.cs
+++ b/SS14.Launcher/Models/Connector.cs
@@ -611,7 +611,8 @@ public class Connector : ReactiveObject
             { "MARSEY_BACKPORTS", _cfg.GetCVar(CVars.Backports) ? "true" : null },
             { "MARSEY_NO_ANY_BACKPORTS", _cfg.GetCVar(CVars.DisableAnyEngineBackports) ? "true" : null },
             { "MARSEY_DISABLE_STRICT", _cfg.GetCVar(CVars.DisableStrict) ? "true" : null },
-            { "MARSEY_DUMP_ASSEMBLIES", MarseyConf.Dumper ? "true" : null }
+            { "MARSEY_DUMP_ASSEMBLIES", MarseyConf.Dumper ? "true" : null },
+            { "MARSEY_PATCHLESS", _cfg.GetCVar(CVars.Patchless) ? "true" : null }
         };
 
         // Serialize environment variables

--- a/SS14.Launcher/Models/Connector.cs
+++ b/SS14.Launcher/Models/Connector.cs
@@ -573,6 +573,9 @@ public class Connector : ReactiveObject
         startInfo.EnvironmentVariables["SS14_LOADER_CONTENT_VERSION"] = contentVersion.ToString();
         startInfo.EnvironmentVariables["SS14_LAUNCHER_PATH"] = Process.GetCurrentProcess().MainModule!.FileName;
 
+        if (_cfg.GetCVar(CVars.DisallowHwid))
+            startInfo.EnvironmentVariables["ROBUST_AUTH_ALLOW_HWID"] = "0";
+
         return startInfo;
     }
 

--- a/SS14.Launcher/Models/Data/CVars.cs
+++ b/SS14.Launcher/Models/Data/CVars.cs
@@ -264,6 +264,11 @@ public static class CVars
     /// Do not patch anything in the game modules
     /// </summary>
     public static readonly CVarDef<bool> Patchless = CVarDef.Create("Patchless", false);
+
+    /// <summary>
+    /// HWID2 - Disallow sending hwid to server.
+    /// </summary>
+    public static readonly CVarDef<bool> DisallowHwid = CVarDef.Create("DisallowHwid", false);
 }
 
 /// <summary>

--- a/SS14.Launcher/Models/Data/CVars.cs
+++ b/SS14.Launcher/Models/Data/CVars.cs
@@ -259,6 +259,11 @@ public static class CVars
     /// Username used in guest mode
     /// </summary>
     public static readonly CVarDef<string> GuestUsername = CVarDef.Create("GuestUsername", "Guest");
+
+    /// <summary>
+    /// Do not patch anything in the game modules
+    /// </summary>
+    public static readonly CVarDef<bool> Patchless = CVarDef.Create("Patchless", false);
 }
 
 /// <summary>

--- a/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
@@ -499,6 +499,16 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
         set => MarseyConf.Dumper = value;
     }
 
+    public bool HWID2OptOut
+    {
+        get => Cfg.GetCVar(CVars.DisallowHwid);
+        set
+        {
+            Cfg.SetCVar(CVars.DisallowHwid, value);
+            Cfg.CommitConfig();
+        }
+    }
+
     public bool Patchless
     {
         get => Cfg.GetCVar(CVars.Patchless);

--- a/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
+++ b/SS14.Launcher/ViewModels/MainWindowTabs/OptionsTabViewModel.cs
@@ -499,6 +499,16 @@ public class OptionsTabViewModel : MainWindowTabViewModel, INotifyPropertyChange
         set => MarseyConf.Dumper = value;
     }
 
+    public bool Patchless
+    {
+        get => Cfg.GetCVar(CVars.Patchless);
+        set
+        {
+            Cfg.SetCVar(CVars.Patchless, value);
+            Cfg.CommitConfig();
+        }
+    }
+
     public bool ResourceOverride
     {
         get => Cfg.GetCVar(CVars.DisableStrict);

--- a/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
@@ -19,6 +19,14 @@
       <ScrollViewer HorizontalScrollBarVisibility="Disabled">
         <DockPanel>
           <StackPanel Orientation="Vertical">
+            <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding HWID2OptOut}">Explicitly disallow HWID</CheckBox>
+            <StackPanel Margin="8">
+              <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
+                         Text="[Patchless] HWId2 - Opt out of sending your HWId to the server."/>
+              <TextBlock VerticalAlignment="Center" FontWeight="Bold" TextWrapping="Wrap"
+                         Text="Servers may require a HWId in the future, as HWId2 works (sort of) on Linux."/>
+            </StackPanel>
+
             <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding CompatMode}">Compatibility Mode</CheckBox>
             <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
                        Text="This uses OpenGL ES 2 (via ANGLE if necessary), which is less likely to suffer from driver bugs. Try this if you are experiencing graphical issues or crashes."
@@ -127,6 +135,8 @@
                             Text="Gives a random HWId each time you connect to a server."/>
                  <TextBlock VerticalAlignment="Center" FontWeight="Bold" TextWrapping="Wrap"
                             Text="Detection vector. Don't use on main accounts."/>
+                 <TextBlock VerticalAlignment="Center" FontWeight="Bold" TextWrapping="Wrap"
+                            Text="HWId2 - a lot of hwids on one account may harm trust in the future."/>
              </StackPanel>
 
              <TextBlock Margin="4, 0" Text="Patching" Classes="NanoHeadingMedium" />

--- a/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/OptionsTabView.xaml
@@ -251,6 +251,11 @@
       <ScrollViewer HorizontalScrollBarVisibility="Disabled">
         <DockPanel>
           <StackPanel Orientation="Vertical">
+            <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding Patchless}">Run patchless</CheckBox>
+            <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"
+                       Text="Disables any patching except hiding harmony, essentially acting like a killswitch. Useful when game breaks due to the launcher itself."
+                       Margin="8" />
+
             <TextBlock Margin="4, 0" Text="Patches" Classes="NanoHeadingMedium" />
             <CheckBox VerticalAlignment="Center" Margin="4" IsChecked="{Binding DumpAssemblies}">Dump Resources</CheckBox>
             <TextBlock VerticalAlignment="Center" TextWrapping="Wrap"

--- a/SS14.Launcher/Views/MainWindowTabs/PatchesTabView.xaml
+++ b/SS14.Launcher/Views/MainWindowTabs/PatchesTabView.xaml
@@ -120,11 +120,15 @@
           </ScrollViewer>
         </TabItem>
       </TabControl>
-      <StackPanel Orientation="Horizontal" Grid.Row="1" VerticalAlignment="Bottom" HorizontalAlignment="Right">
-        <Button Content="Open mod directory" Margin="4, 0" HorizontalAlignment="Right"
-                Command="{Binding OpenPatchDirectoryCommand}" Height="30"/>
-        <Button Content="Recheck mods" Margin="4, 0" HorizontalAlignment="Right"
-                Command="{Binding ReloadModsCommand}" Height="30"/>
+      <StackPanel Orientation="Horizontal" Grid.Row="1" VerticalAlignment="Bottom" HorizontalAlignment="Center">
+        <DockPanel LastChildFill="True">
+          <TextBlock Text="Patches are unsandboxed, run at own risk."
+                     VerticalAlignment="Bottom" FontWeight="Bold" HorizontalAlignment="Left" DockPanel.Dock="Left"/>
+          <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Open mod directory" Margin="4, 0" Command="{Binding OpenPatchDirectoryCommand}" Height="30"/>
+            <Button Content="Recheck mods" Margin="4, 0" Command="{Binding ReloadModsCommand}" Height="30"/>
+          </StackPanel>
+        </DockPanel>
       </StackPanel>
     </Grid>
   </ScrollViewer>


### PR DESCRIPTION
In response to https://github.com/space-wizards/RobustToolbox/pull/5446 and https://github.com/space-wizards/SS14.Web/pull/26.

See https://github.com/ValidHunters/Marseyloader/blob/4e4b9dbb9c845e1bccc8e9a5f5c21f3b58b8bb36/Marsey/Game/Patches/HWID.cs#L24-L28
I suspect the env var to be bait which server hosts can filter players with. Long-term evasion on a single account is unaffected, however some system of keeping track of which auth hwid which account has would be required.

Will finish this when I am back home from Rosh Hashanah

* [x] ROBUST_AUTH_ALLOW_HWID